### PR TITLE
fix: Add mainDir to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "addon"
   ],
   "main": "denali-build.js",
+  "mainDir": "dist",
   "dependencies": {
     "bluebird": "^3.4.7",
     "broccoli-babel-transpiler": "^6.0.0-alpha.2",


### PR DESCRIPTION
Resolves `denali g` not working since it tries to load the wrong data when loading denali-babel.