### PR TITLE
fix: Update babelrc to match node 7.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: node_js
 node_js:
-  - "6.9"
-  - "7"
+  - "7.6"
+  - "8"
 sudo: false
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -23,17 +23,6 @@ transformation.
 
 For more details, check out [the Babel docs](https://babeljs.io/docs/usage/babelrc/).
 
-## Caveats
-
-Because not every planned feature of the JavaScript language can be perfectly transpiled to older
-syntax, there are limitations to Babel's output.
-
-One limitation in particular is important for Denali users. Denali makes heavy use of async/await
-syntax, and the default `.babelrc` configuration includes support for that syntax. However,
-Babel's implementation of async/await
-[does not support `super` properly](https://github.com/babel/babel/issues/3930). So be aware that
-any time you need to use `super`, you'll need to avoid async/await syntax.
-
 
 [npm-url]: https://npmjs.org/package/denali-babel
 [npm-image]: https://img.shields.io/npm/v/denali-babel.svg?style=flat-square

--- a/blueprints/denali-babel/files/.babelrc
+++ b/blueprints/denali-babel/files/.babelrc
@@ -1,16 +1,9 @@
 {
   "plugins": [
-    "transform-exponentiation-operator",
     "syntax-trailing-function-commas",
-    "transform-es2015-arrow-functions",
-    "transform-es2015-template-literals",
     "transform-es2015-spread",
-    "transform-es2015-shorthand-properties",
-    "transform-es2015-destructuring",
     "transform-class-properties",
     "transform-es2015-modules-commonjs",
-    "transform-regenerator",
-    "syntax-async-functions",
     "transform-runtime"
   ],
   "ignore": [


### PR DESCRIPTION
Fixes #1 and improves resulting code form babel transpile.
Also, updates Travis to test against node 7.6 and 8.

I used http://node.green/ to double check if the plugins were required for node 7.6